### PR TITLE
Mod Precondition Permissions Fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/src/listeners/messages/messageUpdate.ts
+++ b/src/listeners/messages/messageUpdate.ts
@@ -5,6 +5,9 @@ import type { Message } from 'discord.js'
 @ApplyOptions<ListenerOptions>({
   event: Events.MessageUpdate
 })
+/**
+ * Replay Message events for handling upon update
+ */
 export default class messageUpdate extends Listener {
   public run(oldMsg: Message, newMsg: Message) {
     if (oldMsg.content === newMsg.content) return null

--- a/src/preconditions/Admin.ts
+++ b/src/preconditions/Admin.ts
@@ -6,6 +6,6 @@ export default class Admin extends Precondition {
     if (!message.guild) return this.error({ message: 'You cannot run this command in DMs.' })
     return message.member.permissions.has('ADMINISTRATOR')
       ? this.ok()
-      : this.error({ message: 'You are not a Administrator.' })
+      : this.error({ message: 'You are not an Administrator.' })
   }
 }

--- a/src/preconditions/Mod.ts
+++ b/src/preconditions/Mod.ts
@@ -1,11 +1,29 @@
 import { Precondition, PreconditionResult } from '@sapphire/framework'
 import type { Message } from 'discord.js'
+import { Permissions } from 'discord.js'
+
+const authorizingPermissions = [
+  Permissions.FLAGS.KICK_MEMBERS,
+  Permissions.FLAGS.BAN_MEMBERS,
+  Permissions.FLAGS.MANAGE_GUILD,
+  Permissions.FLAGS.MANAGE_CHANNELS
+]
 
 export default class Mod extends Precondition {
   public run(message: Message): PreconditionResult {
     if (!message.guild) return this.error({ message: 'You cannot run this command in DMs.' })
-    return message.member.permissions.has('KICK_MEMBERS' || 'BAN_MEMBERS' || 'MANAGE_GUILD' || 'MANAGE_CHANNELS')
-      ? this.ok()
-      : this.error({ message: 'You aren\'t allowed to execute this command.' })
+
+    let isAuthorized = false
+
+    for (const perm of authorizingPermissions) {
+      if (message.member.permissions.has(perm)) {
+        isAuthorized = true
+        break
+      }
+    }
+
+    if (isAuthorized) return this.ok()
+
+    return this.error({ message: 'You aren\'t allowed to execute this command.' })
   }
 }


### PR DESCRIPTION
### Permission Check
* Added an array with authorizing permissions
* set local variable `isAuthorized` when user matches >= 1 of the given permissions
* `ok()` when `isAuthorized` is true

### Chores
* Fix typo in Admin precondition error message
* add .gitattributes with configuration for line endings, forcing lf.
  * done so eslint and windows don't mess with each other on every clone.
* Add comment to messageUpdate event, explaining the replay.